### PR TITLE
アイテムの作成後にページのトップにスクロールする

### DIFF
--- a/Implem.Pleasanter/Scripts/Item.js
+++ b/Implem.Pleasanter/Scripts/Item.js
@@ -29,6 +29,7 @@ $p.new = function ($control) {
 $p.create = function ($control) {
     $p.syncSend($control);
     history.replaceState(null, null, $('#BaseUrl').val() + $('#Id').val());
+    $('body,html').animate({scrollTop: 0}, 500);
 }
 
 $p.copy = function ($control) {


### PR DESCRIPTION
連続してアイテムを作成する時に、新規作成ボタンを押しやすい用に、アイテム作成後はトップに自動スクロールするようにしました。
もしよければマージをお願いします。