### PR TITLE
入力欄をフォーカスした時の背景色を変える

### DIFF
--- a/Implem.Pleasanter/Styles/Site.css
+++ b/Implem.Pleasanter/Styles/Site.css
@@ -2659,3 +2659,10 @@ h3.title-header{
     margin:0px 5px 0px 0px;
 }
 
+textarea:focus{
+    background-color:#ffffcc;
+}
+    
+input:focus{
+    background-color:#ffffcc;
+}


### PR DESCRIPTION
利用者から、低輝度のディスプレイで作業していると、入力欄にフォーカスした時にグレーから白色に色がかわってもわかりづらく、入力出来る状態にあるかどうかわからないといった声がありました。
そこで、入力可能欄にフォーカスした時に背景色を`#ffffcc`に変えるように変更を加えてみました。
利用者からは分かりやすくなったと好評だったので、プルリクを送ってみます。