### PR TITLE
x86環境以外でDockerイメージをビルドできない問題を修正

### DIFF
--- a/Implem.CodeDefiner/Dockerfile
+++ b/Implem.CodeDefiner/Dockerfile
@@ -21,10 +21,10 @@ RUN dotnet build "Implem.CodeDefiner/Implem.CodeDefiner.csproj" -c Release -o /a
 RUN dotnet build "Implem.Pleasanter/Implem.Pleasanter.csproj" -c Release -o /app/build/Implem.Pleasanter
 
 FROM build AS publish
+RUN apt-get update && apt-get install -y jq
 RUN dotnet publish "Implem.CodeDefiner/Implem.CodeDefiner.csproj" -c Release -o /app/publish/Implem.CodeDefiner
 RUN dotnet publish "Implem.Pleasanter/Implem.Pleasanter.csproj" -c Release -o /app/publish/Implem.Pleasanter
-RUN curl -o /usr/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/bin/jq && \
-    cat Implem.Pleasanter/App_Data/Parameters/Rds.json \
+RUN cat Implem.Pleasanter/App_Data/Parameters/Rds.json \
     | jq '.Dbms|="PostgreSQL" | .SaConnectionString|=null | .OwnerConnectionString|=null | .UserConnectionString|=null' \
     > /app/publish/Implem.Pleasanter/App_Data/Parameters/Rds.json
 

--- a/Implem.Pleasanter/Dockerfile
+++ b/Implem.Pleasanter/Dockerfile
@@ -24,9 +24,9 @@ WORKDIR "/src/Implem.Pleasanter"
 RUN dotnet build "Implem.Pleasanter.csproj" -c Release -o /app/build
 
 FROM build AS publish
+RUN apt-get update && apt-get install -y jq
 RUN dotnet publish "Implem.Pleasanter.csproj" -c Release -o /app/publish
-RUN curl -o /usr/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/bin/jq && \
-    cat App_Data/Parameters/Rds.json \
+RUN cat App_Data/Parameters/Rds.json \
     | jq '.Dbms|="PostgreSQL" | .SaConnectionString|=null | .OwnerConnectionString|=null | .UserConnectionString|=null' \
     > /app/publish/App_Data/Parameters/Rds.json
 


### PR DESCRIPTION
arm環境などではjqのバイナリが取得できずビルドする事ができなかった。
パッケージマネージャーが管理するバイナリを使用することにより、arm環境でもdockerイメージをビルドできるように修正。
