### PR TITLE
Docker版CodeDefinerのバージョン指定タグ追加 ( #605 )

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -51,7 +51,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: implem/pleasanter
-          tags: codedefiner
+          tags: |
+            codedefiner
+            codedefiner-${{ steps.split.outputs.RELEASEVER }}
       - name: Build and push (CodeDefiner)
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
#605 をクローズします。
このプルリクエストでは、Docker版CodeDefinerのタグに、新たに `codedefiner-{RELEASEVER}` を追加します。