### PR TITLE
設定 `ServerScriptHttpClientTimeOut` を追加

### DIFF
--- a/Implem.ParameterAccessor/Parts/Script.cs
+++ b/Implem.ParameterAccessor/Parts/Script.cs
@@ -5,6 +5,7 @@
         public bool ServerScript;
         public bool BackgroundServerScript;
         public bool DisableServerScriptHttpClient;
+        public long ServerScriptHttpClientTimeOut;
         public long ServerScriptTimeOut;
         public bool ServerScriptTimeOutChangeable;
         public int ServerScriptTimeOutMin;

--- a/Implem.Pleasanter/App_Data/Parameters/Script.json
+++ b/Implem.Pleasanter/App_Data/Parameters/Script.json
@@ -2,6 +2,7 @@
     "ServerScript": true,
     "BackgroundServerScript": false,
     "DisableServerScriptHttpClient": false,
+    "ServerScriptHttpClientTimeOut": 100,
     "ServerScriptTimeOut": 10000,
     "ServerScriptTimeOutChangeable": false,
     "ServerScriptTimeOutMin": 0,

--- a/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptModelHttpClient.cs
+++ b/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptModelHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Implem.DefinitionAccessor;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -18,6 +19,7 @@ namespace Implem.Pleasanter.Libraries.ServerScripts
         static ServerScriptModelHttpClient()
         {
             _httpClient = new HttpClient();
+            _httpClient.Timeout = TimeSpan.FromSeconds(Parameters.Script.ServerScriptHttpClientTimeOut);
         }
 
         public string Get()

--- a/Implem.Pleasanter/wwwroot/scripts/responsive.js
+++ b/Implem.Pleasanter/wwwroot/scripts/responsive.js
@@ -74,10 +74,12 @@ $.each($toggleBtns, function (i, el) {
     });
 });
 
-if (screen.width < 1025) {
-    $p.send($('#ReduceViewFilters'));
-    $p.send($('#ReduceAggregations'));
-}
+$(document).ready(function () {
+    if (screen.width < 1025) {
+        $p.send($('#ReduceViewFilters'));
+        $p.send($('#ReduceAggregations'));
+    }
+});
 
 $(document).ready(function () {
     function handleSMobileViewport() {


### PR DESCRIPTION
このプルリクエストでは、サーバースクリプトにおけるHTTPクライアントのタイムアウトを、設定ファイルから任意の秒数に変更できるようにします。

設定ファイル `Script.json` に新たなプロパティ `ServerScriptHttpClientTimeOut` を追加します。

#640 を解決します。