### PR TITLE
ロードバランサー配下で外部KVS使用時にセッション情報を共有できるようにする

### DIFF
--- a/Implem.Pleasanter/Startup.cs
+++ b/Implem.Pleasanter/Startup.cs
@@ -203,6 +203,12 @@ namespace Implem.Pleasanter.NetCore
                 var blobClient = blobContainer.GetBlobClient(Parameters.Security.AspNetCoreDataProtection?.KeyFileName ?? "keys.xml");
                 services
                     .AddDataProtection()
+                    .SetApplicationName(
+                        Strings.CoalesceEmpty(
+                            Parameters.Service.EnvironmentName,
+                            Parameters.Service.Name
+                        )
+                    )
                     .PersistKeysToAzureBlobStorage(blobClient)
                     .ProtectKeysWithAzureKeyVault(new Uri(keyIdentifier), new DefaultAzureCredential());
             }


### PR DESCRIPTION
Pleasanterがロードバランサーの配下で複数インスタンス稼働している場合、それぞれが共通の外部KVSに接続できるようにします。

現在の構成では、セッションデータを保護する暗号化トークンがインスタンス毎に異なるため、ラウンドロビン等で前回のインスタンスとは異なるインスタンスにアクセスすると、セッションデータを復号できません。

そこで各インスタンスの `SetApplicationName` を共通の値に設定することで、どのインスタンスにアクセスしても復号可能になります。

共通となる値はとりあえず `Parameters.Service.EnvironmentName` もしくは `Parameters.Service.Name` を使用するようにしていますが、新規に別の専用プロパティを立てて使用するほうが良ければ、そのようにします。