### PR TITLE
docker compose の改修

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
+**/.env.example
 
 **/TestResults/**
 **/*.trx

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# PostgreSQL settings
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=SetSaPWD
+POSTGRES_DB=postgres
+
+# Pleasanter connection strings
+# Server must be "db" (the docker-compose service name)
+Implem_Pleasanter_Rds_PostgreSQL_SaConnectionString=Server=db;Database=postgres;UID=postgres;PWD=SetSaPWD
+Implem_Pleasanter_Rds_PostgreSQL_OwnerConnectionString=Server=db;Database=Implem.Pleasanter;UID=Implem.Pleasanter_Owner;PWD=SetAdminsPWD
+Implem_Pleasanter_Rds_PostgreSQL_UserConnectionString=Server=db;Database=Implem.Pleasanter;UID=Implem.Pleasanter_User;PWD=SetUsersPWD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-﻿version: '3.5'
-
 services:
   Implem.Pleasanter:
     build:
@@ -11,8 +9,11 @@ services:
         - Implem.Pleasanter_Rds_PostgreSQL_UserConnectionString=${Implem_Pleasanter_Rds_PostgreSQL_UserConnectionString}
     image: implem.pleasanter
     container_name: pleasanter
+    ports:
+      - "8080:8080"
     depends_on:
-      - db
+      Implem.CodeDefiner:
+        condition: service_completed_successfully
     networks:
       - default
   Implem.CodeDefiner:
@@ -25,8 +26,10 @@ services:
         - Implem.Pleasanter_Rds_PostgreSQL_UserConnectionString=${Implem_Pleasanter_Rds_PostgreSQL_UserConnectionString}
     image: implem.codedefiner
     container_name: codedefiner
+    command: ["_rds", "/y"]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     networks:
       - default
   db:
@@ -38,10 +41,19 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
       - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
-    ports:
-      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       - default
+volumes:
+  pgdata:
 networks:
   default:
     name: pleasanternetwork


### PR DESCRIPTION
- .env.exampleを追加
- docker compose を.envをコピーするだけで実行可能にした
- PostgreSQLのデータを永続化できるようにvolumeを追加
- docker compose のversionを削除