### PR TITLE
コンテナ環境向けHTMLキャッシュ無効化ミドルウェアを追加

### DIFF
--- a/Implem.ParameterAccessor/Parts/Service.cs
+++ b/Implem.ParameterAccessor/Parts/Service.cs
@@ -20,5 +20,6 @@
         public bool DemoApi;
         public int DemoUsagePeriod;
         public bool RestrictNewFeatures;
+        public bool DisableHtmlCache;
     }
 }

--- a/Implem.Pleasanter/Middlewares/NoCacheHtmlMiddleware.cs
+++ b/Implem.Pleasanter/Middlewares/NoCacheHtmlMiddleware.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Threading.Tasks;
+
+namespace Implem.Pleasanter.Middlewares
+{
+    /// <summary>
+    /// Middleware that adds Cache-Control headers to HTML responses to prevent browser caching.
+    ///
+    /// This is useful in containerized environments (Kubernetes, Docker Swarm, SPCS, etc.)
+    /// where services may be suspended and resumed. Without this middleware, browsers may
+    /// cache error pages (503, auth redirects) during downtime and continue displaying
+    /// them after the service recovers.
+    ///
+    /// Configuration:
+    ///   Service.json: "DisableHtmlCache": true
+    ///   Or environment variable: PLEASANTER_DISABLE_HTML_CACHE=true
+    ///
+    /// When enabled, HTML responses (text/html) will include:
+    ///   Cache-Control: no-cache, no-store, must-revalidate
+    ///   Pragma: no-cache
+    ///   Expires: 0
+    ///
+    /// Static assets (JS, CSS, images) are not affected.
+    /// </summary>
+    public class NoCacheHtmlMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public NoCacheHtmlMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            context.Response.OnStarting(() =>
+            {
+                var contentType = context.Response.ContentType;
+                if (!string.IsNullOrEmpty(contentType) &&
+                    contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                    context.Response.Headers["Pragma"] = "no-cache";
+                    context.Response.Headers["Expires"] = "0";
+                }
+                return Task.CompletedTask;
+            });
+
+            await _next(context);
+        }
+    }
+
+    public static class NoCacheHtmlMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseNoCacheHtml(this IApplicationBuilder app)
+        {
+            return app.UseMiddleware<NoCacheHtmlMiddleware>();
+        }
+    }
+}

--- a/Implem.Pleasanter/Startup.cs
+++ b/Implem.Pleasanter/Startup.cs
@@ -377,6 +377,11 @@ namespace Implem.Pleasanter.NetCore
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseForwardedHeaders();
+            if (Parameters.Service.DisableHtmlCache
+                || !Environment.GetEnvironmentVariable("PLEASANTER_DISABLE_HTML_CACHE").IsNullOrEmpty())
+            {
+                app.UseNoCacheHtml();
+            }
             app.UseCurrentRequestContext();
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
コンテナ環境（Kubernetes、Docker Swarm、Snowflake SPCS等）でサービスが 一時停止・再開される際に発生するブラウザキャッシュ問題を解決します。

この機能がない場合、サービス停止中にブラウザがエラーページ（503、認証リダイレクト）
をキャッシュし、サービス復旧後も古いエラーページを表示し続ける問題があります。

設定方法：
- Service.json: "DisableHtmlCache": true
- または環境変数: PLEASANTER_DISABLE_HTML_CACHE=true

有効時、HTMLレスポンスに以下のヘッダーが付与されます：
- Cache-Control: no-cache, no-store, must-revalidate
- Pragma: no-cache
- Expires: 0

静的アセット（JS、CSS、画像）には影響しません。