### PR TITLE
共有サーバースクリプトを条件ごとに1回だけ実行するよう修正

### DIFF
--- a/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptUtilities.cs
+++ b/Implem.Pleasanter/Libraries/ServerScripts/ServerScriptUtilities.cs
@@ -1243,13 +1243,24 @@ namespace Implem.Pleasanter.Libraries.ServerScripts
             {
                 return null;
             }
-            var scripts = ss
+            var serverScripts = ss
                 ?.GetServerScripts(context: context)
+                ?.ToArray();
+            var scripts = serverScripts
                 ?.Where(where)
                 .ToArray();
             if (scripts?.Any() != true)
             {
                 return null;
+            }
+            var sharedBody = serverScripts?
+                .Where(script => script.Shared == true)
+                .Select(script => script.Body)
+                .Join("\n");
+            if (!sharedBody.IsNullOrEmpty())
+            {
+                scripts[0] = scripts[0].GetRecordingData();
+                scripts[0].Body = sharedBody + "\n" + scripts[0].Body;
             }
             var scriptValues = Execute(
                 context: context,

--- a/Implem.Pleasanter/Libraries/Settings/SiteSettings.cs
+++ b/Implem.Pleasanter/Libraries/Settings/SiteSettings.cs
@@ -6164,13 +6164,6 @@ namespace Implem.Pleasanter.Libraries.Settings
                     .ForEach(serverScript =>
                     {
                         serverScript.SetDebug();
-                        var body = serverScript.Body;
-                        var sharedServerScripts = SharedServerScripts(serverScripts: ServerScriptsAndExtended);
-                        if (!sharedServerScripts.IsNullOrEmpty())
-                        {
-                            body = sharedServerScripts + "\n" + body;
-                        }
-                        serverScript.Body = body;
                     });
                 ServerScriptsAndExtended.ForEach(serverScript =>
                 {
@@ -6182,14 +6175,6 @@ namespace Implem.Pleasanter.Libraries.Settings
                 });
                 return ServerScriptsAndExtended;
             }
-        }
-
-        private string SharedServerScripts(List<ServerScript> serverScripts)
-        {
-            return serverScripts
-                .Where(o => o.Shared == true)
-                .Select(o => o.Body)
-                .Join("\n");
         }
 
         private string IncludedServerScripts(


### PR DESCRIPTION
Fixes #702

同一条件に複数のサーバースクリプトがある場合、共有サーバースクリプトが各スクリプトへ繰り返し展開されることで、`const` の再宣言エラーが発生していました。
本修正では、共有サーバースクリプトを条件ごとの実行時に1回だけ先頭へ付与するように変更しています。
ISSUE作成者が例として挙げてるような共有1本と 更新前2本の構成で再現確認し、修正後はエラーなく保存できること、および共有値を後続スクリプトから参照できることを確認しました。